### PR TITLE
[BUGFIX] Use valid suggestion constraint in `ext_emconf.php`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,7 @@ $EM_CONF[$_EXTKEY] = [
         ],
         'conflicts' => [],
         'suggests' => [
-            'paginated_processor'
+            'paginated_processor' => '*',
         ]
     ]
 ];


### PR DESCRIPTION
TYPO3 Core composer package manager complains about invalid
suggestion constraint in `ext_emconf.php` file within this
extension.

Taking the TYPO3 documentation into account [1], the suggest
constraint should mention the suggested extension as key and
the constraint as value, but the extension simple mention it
only as value.

Respecting all above-mentioned facts, this change modifies
the `ext_emconf.php` to name the extension as key and use
wild-card `*` constraint because there is no released version
of `EXT:paginated_processor` matching the supported TYPO3
version.

[1] https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/FileStructure/ExtEmconf.html#confval-ext-emconf-constraints

That avoids for example following error in functional tests:

```
1) WebVision\ProjectTests\Tests\Functional\ExtensionsLoadedTest::extensionIsLoadedReturnsTrue with data set #0 ('backend')
TYPO3\CMS\Core\Package\Exception\InvalidPackageManifestException: The extension "just_news" has invalid version constraints in suggests section. Extension key is missing!

/var/www/html/vendor/typo3/cms-core/Classes/Package/PackageManager.php:927
/var/www/html/vendor/typo3/cms-core/Classes/Package/PackageManager.php:847
/var/www/html/vendor/typo3/cms-core/Classes/Package/Package.php:97
/var/www/html/vendor/typo3/testing-framework/Classes/Core/PackageCollection.php:92
/var/www/html/vendor/typo3/testing-framework/Classes/Core/Testbase.php:653
/var/www/html/vendor/typo3/testing-framework/Classes/Core/Functional/FunctionalTestCase.php:423
```

Looking into related TYPO3 Core code of the above-mentioned place in file
`typo3/sysext/core/Classes/Package/PackageManager.php` and method
`mapExtensionManagerConfigurationToComposerManifest`:

```php
        if (isset($extensionManagerConfiguration['constraints']['suggests']) && is_array($extensionManagerConfiguration['constraints']['suggests'])) {
            foreach ($extensionManagerConfiguration['constraints']['suggests'] as $suggestedPackageKey => $suggestedPackageVersion) {
                if (!empty($suggestedPackageKey)) {
                    $composerManifest->suggest->$suggestedPackageKey = $suggestedPackageVersion;
                } else {
                    throw new InvalidPackageManifestException(sprintf('The extension "%s" has invalid version constraints in suggests section. Extension key is missing!', $packageKey), 1439552060);
                }
            }
        }
```

The empty check is bad as in case first suggestion has a key => value pair and a subsequent suggestion is only mentioned as value. Beside that bad check, the place makes clear that suggestions are expected in the form of:

```
 '<extension_key>' => '<constraint>',
``` 

like documented and should be fixed.

Removing the suggestion from `ext_emconf.php` AND `composer.json` not having a suitable TYPO3 v13 version released in TER anyway.